### PR TITLE
feat(rust): add support for rust

### DIFF
--- a/cmd/fuck-u-code/main.go
+++ b/cmd/fuck-u-code/main.go
@@ -62,6 +62,9 @@ var defaultExcludes = []string{
 	"**/*_test.c", "**/*_test.cpp", "**/*_tests.c", "**/*_tests.cpp",
 	"**/test/**/**.c", "**/test/**/**.cpp", "**/tests/**/**.c", "**/tests/**/**.cpp",
 	"**/gtest/**", "**/googletest/**", "**/catch/**", "**/boost/test/**",
+
+	// for rust
+	"**/benches/**", "**/examples/**", "**/build.rs",
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/robertkrimen/otto v0.2.1 h1:FVP0PJ0AHIjC+N4pKCG9yCDz6LHNPCwi/GKID5pGGF0=
 github.com/robertkrimen/otto v0.2.1/go.mod h1:UPwtJ1Xu7JrLcZjNWN8orJaM5n5YEtqL//farB5FlRY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/common/language.go
+++ b/pkg/common/language.go
@@ -13,6 +13,7 @@ type LanguageType string
 // 支持的编程语言常量定义
 const (
 	Go          LanguageType = "go"
+	Rust        LanguageType = "rust"
 	JavaScript  LanguageType = "javascript"
 	TypeScript  LanguageType = "typescript"
 	Python      LanguageType = "python"
@@ -25,6 +26,7 @@ const (
 // supportedLanguages 用于快速查找支持的语言
 var supportedLanguages = map[LanguageType]bool{
 	Go:         true,
+	Rust:       true,
 	JavaScript: true,
 	TypeScript: true,
 	Python:     true,
@@ -68,6 +70,8 @@ func (d *DefaultDetector) DetectLanguage(filePath string) LanguageType {
 		return CPlusPlus
 	case ".c", ".h":
 		return C
+	case ".rs":
+		return Rust
 	default:
 		return Unsupported
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -88,6 +88,8 @@ func CreateParser(language common.LanguageType) Parser {
 	switch language {
 	case common.Go:
 		return NewGoParser()
+	case common.Rust:
+		return NewRustParser()
 	case common.JavaScript:
 		return NewJavaScriptParser()
 	case common.TypeScript:

--- a/pkg/parser/rust_parser.go
+++ b/pkg/parser/rust_parser.go
@@ -1,0 +1,210 @@
+package parser
+
+import (
+	"context"
+	"github.com/Done-0/fuck-u-code/pkg/common"
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/rust"
+)
+
+// RustParser RustParser
+type RustParser struct {
+	rootNode *sitter.Node
+}
+
+// NewRustParser create a new rust parser
+func NewRustParser() Parser {
+	return &RustParser{}
+}
+
+// Parse parse rust codes
+func (r *RustParser) Parse(filePath string, content []byte) (ParseResult, error) {
+	parser := sitter.NewParser()
+	parser.SetLanguage(rust.GetLanguage())
+
+	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	if err != nil {
+		return nil, err
+	}
+
+	rootNode := tree.RootNode()
+	r.rootNode = rootNode
+
+	functions, err := r.parseFunction(content)
+	if err != nil {
+		return nil, err
+	}
+
+	totalLines := int(rootNode.EndPoint().Row) + 1
+	commentLines, err := r.calculateCommentLines()
+	if err != nil {
+		return nil, err
+	}
+
+	return &BaseParseResult{
+		Functions:    functions,
+		CommentLines: commentLines,
+		TotalLines:   totalLines,
+		Language:     common.Rust,
+		ASTRoot:      nil,
+	}, nil
+}
+
+// SupportedLanguages return supported languages
+func (r *RustParser) SupportedLanguages() []common.LanguageType {
+	return []common.LanguageType{common.Rust}
+}
+
+// parseFunction parse functions
+func (r *RustParser) parseFunction(allContent []byte) ([]Function, error) {
+	queryStr := `
+((function_item
+  name: (identifier) @function.name
+  parameters: (parameters) @function.parameters
+  body: (block) @function.body) @function.definition)
+`
+
+	query, err := sitter.NewQuery([]byte(queryStr), rust.GetLanguage())
+	if err != nil {
+		return nil, err
+	}
+
+	qc := sitter.NewQueryCursor()
+	qc.Exec(query, r.rootNode)
+
+	var functions []Function
+
+	for {
+		match, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+
+		var funcNameNode, paramsNode, bodyNode, functionNode *sitter.Node
+
+		for _, capture := range match.Captures {
+			captureName := query.CaptureNameForId(capture.Index)
+
+			switch captureName {
+			case "function.name":
+				funcNameNode = capture.Node
+			case "function.parameters":
+				paramsNode = capture.Node
+			case "function.body":
+				bodyNode = capture.Node
+			case "function.definition":
+				functionNode = capture.Node
+			}
+
+			if functionNode != nil && funcNameNode != nil && paramsNode != nil && bodyNode != nil {
+				function, err := parseSingleFunction(funcNameNode, paramsNode, bodyNode, functionNode, allContent)
+				if err != nil {
+					return nil, err
+				}
+
+				functions = append(functions, function)
+			}
+		}
+	}
+
+	return functions, nil
+}
+
+// parseSingleFunction parse a single function
+func parseSingleFunction(
+	funcNameNode *sitter.Node,
+	paramsNode *sitter.Node,
+	bodyNode *sitter.Node,
+	functionNode *sitter.Node,
+	src []byte,
+) (Function, error) {
+	name := funcNameNode.Content(src)
+
+	// row line number starts with 0
+	startLine := int(functionNode.StartPoint().Row) + 1
+	endLine := int(functionNode.EndPoint().Row) + 1
+
+	// parameters may contain `self`, or may not have type annotations. So we should find parameter nodes
+	paramQuery, err := sitter.NewQuery([]byte("((parameter) @param)"), rust.GetLanguage())
+	if err != nil {
+		return Function{}, err
+	}
+
+	paramCursor := sitter.NewQueryCursor()
+	paramCursor.Exec(paramQuery, paramsNode)
+	paramCount := 0
+
+	for {
+		_, ok := paramCursor.NextMatch()
+		if !ok {
+			break
+		}
+		paramCount++
+	}
+
+	complexity := 1
+	complexityQuery, err := sitter.NewQuery(
+		[]byte(`[ (if_expression) (for_expression) (while_expression) (match_arm) (binary_expression) ] @complexity`),
+		rust.GetLanguage(),
+	)
+	if err != nil {
+		return Function{}, err
+	}
+
+	complexityCursor := sitter.NewQueryCursor()
+	complexityCursor.Exec(complexityQuery, bodyNode)
+	for {
+		_, ok := complexityCursor.NextMatch()
+		if !ok {
+			break
+		}
+		complexity++
+	}
+
+	return Function{
+		Name:       name,
+		StartLine:  startLine,
+		EndLine:    endLine,
+		Parameters: paramCount,
+		Complexity: complexity,
+		Node:       nil,
+	}, nil
+}
+
+// calculateCommentLines calculate comment lines
+func (r *RustParser) calculateCommentLines() (int, error) {
+	commentQueryStr := `
+[
+  (line_comment)
+  (block_comment)
+] @comment
+`
+	commentQuery, err := sitter.NewQuery([]byte(commentQueryStr), rust.GetLanguage())
+	if err != nil {
+		return 0, err
+	}
+
+	commentCursor := sitter.NewQueryCursor()
+	commentCursor.Exec(commentQuery, r.rootNode)
+	commentedLines := make(map[int]bool)
+
+	for {
+		match, ok := commentCursor.NextMatch()
+		if !ok {
+			break
+		}
+
+		for _, capture := range match.Captures {
+			commentNode := capture.Node
+
+			startLine := int(commentNode.StartPoint().Row)
+			endLine := int(commentNode.EndPoint().Row)
+
+			for line := startLine; line <= endLine; line++ {
+				commentedLines[line] = true
+			}
+		}
+	}
+
+	return len(commentedLines), nil
+}


### PR DESCRIPTION
🔍 开始嗅探：pkg/parser/rust_parser.go
────────────────────────────────────────────────────────────────────────────────

  🌸 屎山代码分析报告 🌸
────────────────────────────────────────────────────────────────────────────────

  总体评分: 51.46 / 100 - 毒气缭绕，代码审查犹如酷刑
  屎山等级: 中度屎山 - 臭味明显，开窗也救不了


◆ 评分指标详情

  ✓✓ 命名规范             0.00分     命名清晰，程序员的文明之光
  ✓ 错误处理             25.00分    有处理，但处理得跟没处理一样
  ✓ 代码结构             30.00分    结构还行，但有点混乱
  ○ 代码重复度            35.00分    有点重复，抽象一下不难吧
  ○ 状态管理             35.50分    状态管理一般，存在部分全局状态或状态变化不明确的情况
  ⚠ 注释覆盖率            68.67分    没有注释，靠缘分理解吧
  ✗ 循环复杂度            95.00分    函数像迷宫，维护像打副本

  评分计算: (0.00×0.08 + 25.00×0.10 + 30.00×0.15 + 35.00×0.15 + 35.50×0.20 + 68.67×0.15 + 95.00×0.30) ÷ 1.13 = 51.46


◆ 最屎代码排行榜

  1. pkg/parser/rust_parser.go  (屎气指数: 51.46)
     🔄 复杂度问题: 2   📝 注释问题: 1   ⚠️  其他问题: 2

     🔄 函数 parseFunction 的循环复杂度较高 (14)，建议简化
     ⚠️  函数 'parseFunction' () 较长 (53 行)，可考虑重构
     🔄 函数 'parseFunction' () 复杂度过高 (14)，建议简化
     ⚠️  函数 'parseSingleFunction' () 较长 (59 行)，可考虑重构
     📝 代码注释率极低 (4.27%)，几乎没有注释

◆ 诊断结论

  🌸 中度屎山 - 臭味明显，开窗也救不了

  🔧 建议：这代码像个叛逆期的青少年，需要适当管教才能成才

────────────────────────────────────────────────────────────────────────────────


<img width="950" height="819" alt="image" src="https://github.com/user-attachments/assets/8507acb9-7d8a-4a25-a63c-56617752fc41" />
