### PR TITLE
修复估算java函数复杂度时读取的是整个文件内容的问题

### DIFF
--- a/pkg/parser/java_parser.go
+++ b/pkg/parser/java_parser.go
@@ -32,7 +32,7 @@ func (p *JavaParser) Parse(filePath string, content []byte) (ParseResult, error)
 
 	// 由于ANTLR解析器的复杂性，这里使用基于文本的简化分析
 	// 对于实际应用中的完整功能，需要使用完整的ANTLR生成的解析器
-	result.Functions = p.detectJavaFunctions(contentStr, lines)
+	result.Functions = p.detectJavaFunctions(lines)
 
 	return result, nil
 }
@@ -91,7 +91,7 @@ func (p *JavaParser) countCommentLines(content string) int {
 }
 
 // detectJavaFunctions 基于文本分析检测Java方法
-func (p *JavaParser) detectJavaFunctions(content string, lines []string) []Function {
+func (p *JavaParser) detectJavaFunctions(lines []string) []Function {
 	functions := make([]Function, 0)
 
 	// 简化的Java方法检测

--- a/pkg/parser/java_parser.go
+++ b/pkg/parser/java_parser.go
@@ -139,10 +139,13 @@ func (p *JavaParser) detectJavaFunctions(content string, lines []string) []Funct
 					}
 				}
 
+				// 重新计算当前函数的代码
+				functionContent := strings.Join(lines[startLine-1:i+1], "\n")
+
 				// 估算复杂度
-				complexity := 1 + strings.Count(content, "if ") + strings.Count(content, "for ") +
-					strings.Count(content, "while ") + strings.Count(content, "catch ") +
-					strings.Count(content, "case ")
+				complexity := 1 + strings.Count(functionContent, "if ") + strings.Count(functionContent, "for ") +
+					strings.Count(functionContent, "while ") + strings.Count(functionContent, "catch ") +
+					strings.Count(functionContent, "case ")
 
 				functions = append(functions, Function{
 					Name:       currentFunc,


### PR DESCRIPTION
在估算java函数的复杂度的时候，使用的是整个文件的内容，这样会造成每个文件内函数的复杂度都是一样