### PR TITLE
feat(git_remote): 支持拉取远程仓库代码并检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ docker build -t fuck-u-code .
 ## 使用方法
 
 ```bash
-# 基本分析
+# 基本分析 - 本地项目
 fuck-u-code analyze /path/to/project
 # 或
 fuck-u-code /path/to/project
+
+# 分析 Git 仓库（自动克隆）
+fuck-u-code analyze https://github.com/user/repo.git
+# 或
+fuck-u-code https://github.com/user/repo
 
 # Docker 运行
 docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
@@ -47,6 +52,9 @@ docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
 # 默认分析当前目录
 fuck-u-code analyze
 ```
+
+> [!Tip]
+> **支持直接分析 Git 仓库**：工具会自动克隆仓库到临时目录 `tmp_proj` 并在分析后自动清理。支持 GitHub、GitLab、Gitee、Bitbucket 等平台。
 
 ### 常用选项
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -37,10 +37,15 @@ docker build -t fuck-u-code .
 ## Usage
 
 ```bash
-# Basic analysis
+# Basic analysis - local project
 fuck-u-code analyze /path/to/project
 # Or
 fuck-u-code /path/to/project
+
+# Analyze Git repository (auto clone)
+fuck-u-code analyze https://github.com/user/repo.git
+# Or
+fuck-u-code https://github.com/user/repo
 
 # Run with Docker
 docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
@@ -48,6 +53,9 @@ docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
 # Default: analyze current directory
 fuck-u-code analyze
 ```
+
+> [!Tip]
+> **Direct Git repository analysis supported**: The tool automatically clones repositories to a temporary directory `tmp_proj` and cleans up after analysis. Supports GitHub, GitLab, Gitee, Bitbucket, and more.
 
 ### Common Options
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -37,10 +37,15 @@ docker build -t fuck-u-code .
 ## Использование
 
 ```bash
-# Базовый анализ
+# Базовый анализ - локальный проект
 fuck-u-code analyze /path/to/project
 # Или
 fuck-u-code /path/to/project
+
+# Анализ Git репозитория (автоматическое клонирование)
+fuck-u-code analyze https://github.com/user/repo.git
+# Или
+fuck-u-code https://github.com/user/repo
 
 # Запуск с помощью Docker
 docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
@@ -48,6 +53,9 @@ docker run --rm -v "/path/to/project:/build" fuck-u-code analyze
 # По-умолчанию: анализ текущей директории
 fuck-u-code analyze
 ```
+
+> [!Tip]
+> **Поддержка прямого анализа Git репозиториев**: Инструмент автоматически клонирует репозитории во временный каталог `tmp_proj` и очищает его после анализа. Поддерживает GitHub, GitLab, Gitee, Bitbucket и другие платформы.
 
 ### Общие параметры
 

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -1,0 +1,126 @@
+// Package common 提供项目通用功能
+// 创建者：SwimmingLiu
+package common
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// IsGitURL 判断给定的路径是否为 git 仓库链接
+// 参数:
+//   - path: 待检测的路径
+//
+// 返回值:
+//   - bool: 是否为 git 仓库链接
+func IsGitURL(path string) bool {
+	// 常见的 git URL 格式:
+	// - https://github.com/user/repo.git
+	// - http://github.com/user/repo
+	// - git@github.com:user/repo.git
+	// - ssh://git@github.com/user/repo.git
+	gitURLPatterns := []string{
+		`^https?://.*\.git$`,                      // https://xxx.git
+		`^https?://[^/]+/[^/]+/[^/]+/?$`,          // https://domain/user/repo
+		`^git@[^:]+:[^/]+/.+\.git$`,               // git@domain:user/repo.git
+		`^ssh://git@[^/]+/[^/]+/[^/]+\.git$`,      // ssh://git@domain/user/repo.git
+		`^https?://github\.com/[^/]+/[^/]+/?$`,    // github.com URL
+		`^https?://gitlab\.com/[^/]+/[^/]+/?$`,    // gitlab.com URL
+		`^https?://gitee\.com/[^/]+/[^/]+/?$`,     // gitee.com URL
+		`^https?://bitbucket\.org/[^/]+/[^/]+/?$`, // bitbucket.org URL
+	}
+
+	for _, pattern := range gitURLPatterns {
+		matched, _ := regexp.MatchString(pattern, path)
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsGitInstalled 检查系统是否安装了 git
+// 返回值:
+//   - bool: 是否安装了 git
+func IsGitInstalled() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// CloneGitRepo 克隆 git 仓库到指定目录
+// 参数:
+//   - gitURL: git 仓库链接
+//   - targetDir: 目标目录（git clone 会将仓库内容直接克隆到此目录）
+//
+// 返回值:
+//   - error: 可能的错误
+func CloneGitRepo(gitURL, targetDir string) error {
+	// 获取父目录
+	parentDir := filepath.Dir(targetDir)
+
+	// 确保父目录存在（但不创建目标目录本身，让 git clone 来创建）
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return fmt.Errorf("创建父目录失败: %v", err)
+	}
+
+	// 执行 git clone 命令，直接克隆到目标目录
+	cmd := exec.Command("git", "clone", gitURL, targetDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("克隆仓库失败: %v", err)
+	}
+
+	return nil
+}
+
+// RemoveTempDir 删除临时目录
+// 参数:
+//   - dirPath: 要删除的目录路径
+//
+// 返回值:
+//   - error: 可能的错误
+func RemoveTempDir(dirPath string) error {
+	// 确保只删除 tmp_proj 开头的目录，避免误删
+	dirName := filepath.Base(dirPath)
+	if !strings.HasPrefix(dirName, "tmp_proj") {
+		return fmt.Errorf("安全检查失败: 只能删除 tmp_proj 开头的目录")
+	}
+
+	if err := os.RemoveAll(dirPath); err != nil {
+		return fmt.Errorf("删除临时目录失败: %v", err)
+	}
+
+	return nil
+}
+
+// GetTempDir 获取临时目录路径
+// 参数:
+//   - baseDir: 基础目录
+//
+// 返回值:
+//   - string: 临时目录的绝对路径
+//   - error: 可能的错误
+func GetTempDir(baseDir string) (string, error) {
+	// 创建 tmp_proj 目录路径
+	tmpDir := filepath.Join(baseDir, "tmp_proj")
+
+	// 获取绝对路径
+	absPath, err := filepath.Abs(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("获取绝对路径失败: %v", err)
+	}
+
+	// 如果已存在临时目录，则删除
+	if _, err := os.Stat(absPath); err == nil {
+		os.RemoveAll(absPath)
+	}
+
+	return absPath, nil
+}

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -163,6 +163,11 @@ var zhCNMessages = map[string]string{
 	"cmd.skipindex":                  "跳过所有 index.js/index.ts 文件",
 	"cmd.start_analyzing":            "开始嗅探：%s",
 	"cmd.exclude_patterns":           "排除以下文件/目录模式:",
+	"cmd.git_not_installed":          "❌ 错误：未检测到 git，请先安装 git",
+	"cmd.cloning_repo":               "🔄 正在克隆仓库：%s",
+	"cmd.clone_failed":               "❌ 克隆仓库失败：%v\n💡 提示：请检查仓库链接是否有效",
+	"cmd.clone_success":              "✅ 仓库克隆成功",
+	"cmd.cleaning_temp":              "🧹 清理临时文件...",
 
 	// Cobra框架内部文本
 	"cobra.available_commands": "可用命令",
@@ -463,6 +468,11 @@ var enUSMessages = map[string]string{
 	"cmd.skipindex":                  "Skip all index.js/index.ts files",
 	"cmd.start_analyzing":            "Start analyzing: %s",
 	"cmd.exclude_patterns":           "Excluding the following file/directory patterns:",
+	"cmd.git_not_installed":          "❌ Error: git not detected, please install git first",
+	"cmd.cloning_repo":               "🔄 Cloning repository: %s",
+	"cmd.clone_failed":               "❌ Failed to clone repository: %v\n💡 Tip: Please check if the repository URL is valid",
+	"cmd.clone_success":              "✅ Repository cloned successfully",
+	"cmd.cleaning_temp":              "🧹 Cleaning temporary files...",
 
 	// Cobra框架内部文本
 	"cobra.available_commands": "Available Commands",
@@ -751,6 +761,11 @@ var ruRuMessages = map[string]string{
 	"cmd.skipindex":                            "Пропустить все файлы index.js/index.ts",
 	"cmd.start_analyzing":                      "Начать анализ: %s",
 	"cmd.exclude_patterns":                     "За исключением следующих шаблонов файла/каталогов:",
+	"cmd.git_not_installed":                    "❌ Ошибка: git не обнаружен, пожалуйста, сначала установите git",
+	"cmd.cloning_repo":                         "🔄 Клонирование репозитория: %s",
+	"cmd.clone_failed":                         "❌ Не удалось клонировать репозиторий: %v\n💡 Совет: Проверьте, действителен ли URL репозитория",
+	"cmd.clone_success":                        "✅ Репозиторий успешно клонирован",
+	"cmd.cleaning_temp":                        "🧹 Очистка временных файлов...",
 	"cobra.available_commands":                 "Доступные команды",
 	"cobra.flags":                              "Флаги",
 	"cobra.global_flags":                       "Глобальные флаги",


### PR DESCRIPTION
关联issue https://github.com/Done-0/fuck-u-code/issues/91

支持新功能：拉取远程仓库代码并检测

实现方式：

1. 调用本地 `git` 工具，获取制定 `git` 项目地址的代码并存放至临时目录 `tmp_proj`
2. 分析 `tmp_proj` 目录中的代码，并输出分析结果
3. 删除临时目录 `tmp_proj`