### PR TITLE
feat(cli): 添加克隆并分析远程仓库命令

### DIFF
--- a/src/cli/commands/clone-and-analyze.ts
+++ b/src/cli/commands/clone-and-analyze.ts
@@ -1,0 +1,244 @@
+/**
+ * Clone and Analyze command
+ * 克隆 git 仓库并分析代码质量
+ */
+
+import { Command } from 'commander';
+import { resolve } from 'node:path';
+import { loadConfig, createRuntimeConfig } from '../../config/index.js';
+import { createAnalyzer } from '../../analyzer/index.js';
+import { ConsoleOutput } from '../output/console.js';
+import { MarkdownOutput } from '../output/markdown.js';
+import { JsonOutput } from '../output/json.js';
+import { HtmlOutput } from '../output/html.js';
+import { createSpinner, ProgressBar } from '../../utils/progress.js';
+import { exists, isDirectory } from '../../utils/fs.js';
+import { t } from '../../i18n/index.js';
+import { renderMarkdownToTerminal } from '../../utils/markdown.js';
+import chalk from 'chalk';
+import {
+  gitClone,
+  removeTempDir,
+  isValidGitUrl,
+  type GitCloneResult,
+} from '../../utils/git.js';
+
+interface CloneAnalyzeOptions {
+  verbose?: boolean;
+  top?: number;
+  format?: 'console' | 'markdown' | 'json' | 'html';
+  output?: string;
+  exclude?: string[];
+  concurrency?: number;
+  locale?: 'en' | 'zh' | 'ru';
+  keepTemp?: boolean;
+}
+
+export function createCloneAnalyzeCommand(): Command {
+  const command = new Command('clone-and-analyze');
+
+  command
+    .description(t('cmd_clone_analyze_description'))
+    .argument('<git-url>', 'Git repository URL to clone and analyze')
+    .option('-v, --verbose', 'Show verbose output')
+    .option('-t, --top <number>', 'Show top N worst files (default: 10)', parseInt)
+    .option(
+      '-f, --format <format>',
+      'Output format: console, markdown, json, html (default: console)'
+    )
+    .option('-o, --output <file>', 'Write output to file instead of stdout')
+    .option('-e, --exclude <patterns...>', 'Additional glob patterns to exclude')
+    .option('-c, --concurrency <number>', 'Number of concurrent workers (default: 8)', parseInt)
+    .option('-l, --locale <locale>', 'Language: en, zh, ru (default: en)')
+    .option('--keep-temp', 'Keep the temporary directory after analysis')
+    .addHelpText(
+      'after',
+      `
+${t('cli_examples')}
+  $ fuck-u-code clone-and-analyze https://github.com/user/repo.git        # ${t('cmd_clone_analyze_example')}
+  $ fuck-u-code clone-and-analyze git@github.com:user/repo.git            # ${t('cmd_clone_analyze_example_url')}
+  $ fuck-u-code clone-and-analyze https://github.com/user/repo.git -f markdown -o report.md  # ${t('cmd_clone_analyze_example_output')}
+  $ fuck-u-code clone-and-analyze https://github.com/user/repo.git --keep-temp  # ${t('cmd_clone_analyze_example_keep')}
+`
+    )
+    .action(async (gitUrl: string, options: CloneAnalyzeOptions) => {
+      await runCloneAnalyze(gitUrl, options);
+    });
+
+  return command;
+}
+
+async function runCloneAnalyze(gitUrl: string, options: CloneAnalyzeOptions): Promise<void> {
+  // 验证 git URL
+  if (!isValidGitUrl(gitUrl)) {
+    console.error(chalk.red(t('error_invalid_git_url', { url: gitUrl })));
+    process.exit(1);
+  }
+
+  const cloneSpinner = createSpinner(t('progress_cloning'));
+  const discoverySpinner = createSpinner(t('progress_discovering'));
+  const state: { progressBar: ProgressBar | null } = { progressBar: null };
+  let tempDir: string | undefined;
+  let shouldCleanup = true;
+
+  try {
+    // 克隆仓库
+    cloneSpinner.start();
+    const cloneResult: GitCloneResult = await gitClone(gitUrl, {
+      verbose: options.verbose,
+    });
+
+    if (!cloneResult.success) {
+      cloneSpinner.fail(t('progress_clone_failed'));
+      console.error(chalk.red(cloneResult.error));
+      process.exit(1);
+    }
+
+    tempDir = cloneResult.targetDir;
+    cloneSpinner.succeed(t('progress_clone_success'));
+
+    if (options.verbose && tempDir) {
+      console.log(chalk.green(t('info_temp_dir_created', { path: tempDir })));
+    }
+
+    // 如果用户指定保留临时目录，则不清理
+    if (options.keepTemp) {
+      shouldCleanup = false;
+      if (tempDir) {
+        console.log(chalk.yellow(t('info_temp_dir_kept', { path: tempDir })));
+      }
+    }
+
+    const resolvedPath = resolve(tempDir!);
+
+    // 验证路径
+    if (!(await exists(resolvedPath))) {
+      console.error(chalk.red(t('error_path_not_found', { path: resolvedPath })));
+      if (shouldCleanup && tempDir) {
+        await removeTempDir(tempDir);
+      }
+      process.exit(1);
+    }
+
+    if (!(await isDirectory(resolvedPath))) {
+      console.error(chalk.red(t('error_not_a_directory', { path: resolvedPath })));
+      if (shouldCleanup && tempDir) {
+        await removeTempDir(tempDir);
+      }
+      process.exit(1);
+    }
+
+    // 加载配置并分析
+    const config = await loadConfig(resolvedPath);
+    const runtimeConfig = createRuntimeConfig(resolvedPath, config, {
+      verbose: options.verbose,
+      concurrency: options.concurrency,
+      exclude: options.exclude,
+      output: {
+        format: options.format ?? 'console',
+        file: options.output,
+        top: options.top ?? 10,
+        maxIssues: 5,
+        showDetails: true,
+      },
+    });
+
+    const analyzer = createAnalyzer(runtimeConfig, {
+      onDiscoveryStart: () => {
+        discoverySpinner.start();
+      },
+      onDiscoveryComplete: (fileCount) => {
+        discoverySpinner.succeed(t('progress_discovered', { count: fileCount }));
+        if (fileCount > 0) {
+          state.progressBar = new ProgressBar(fileCount, t('progress_analyzing'));
+          state.progressBar.start();
+        }
+      },
+      onAnalysisProgress: (current) => {
+        state.progressBar?.update(current);
+      },
+    });
+
+    const result = await analyzer.analyze();
+
+    state.progressBar?.succeed(t('analysisComplete'));
+
+    // 输出结果
+    const outputFormat = runtimeConfig.output.format;
+    const outputFile = runtimeConfig.output.file;
+
+    switch (outputFormat) {
+      case 'markdown': {
+        const mdOutput = new MarkdownOutput(runtimeConfig);
+        const markdown = mdOutput.render(result);
+        if (outputFile) {
+          const { writeFile } = await import('node:fs/promises');
+          await writeFile(outputFile, markdown, 'utf-8');
+          console.log(t('outputWritten', { file: outputFile }));
+        } else {
+          console.log(renderMarkdownToTerminal(markdown));
+        }
+        break;
+      }
+      case 'json': {
+        const jsonOutput = new JsonOutput();
+        const json = jsonOutput.render(result);
+        if (outputFile) {
+          const { writeFile } = await import('node:fs/promises');
+          await writeFile(outputFile, json, 'utf-8');
+          console.log(t('outputWritten', { file: outputFile }));
+        } else {
+          console.log(json);
+        }
+        break;
+      }
+      case 'html': {
+        const htmlOutput = new HtmlOutput(runtimeConfig);
+        const html = htmlOutput.render(result);
+        if (outputFile) {
+          const { writeFile } = await import('node:fs/promises');
+          await writeFile(outputFile, html, 'utf-8');
+          console.log(t('outputWritten', { file: outputFile }));
+        } else {
+          console.log(chalk.yellow(t('output_html_requires_file')));
+          const consoleOutputFallback = new ConsoleOutput(runtimeConfig);
+          consoleOutputFallback.render(result);
+        }
+        break;
+      }
+      default: {
+        const consoleOutput = new ConsoleOutput(runtimeConfig);
+        consoleOutput.render(result);
+      }
+    }
+
+    // 清理临时目录
+    if (shouldCleanup && tempDir) {
+      const cleanSpinner = createSpinner(t('progress_cleaning'));
+      cleanSpinner.start();
+      const removed = await removeTempDir(tempDir);
+      if (removed) {
+        cleanSpinner.succeed(t('progress_clean_complete'));
+        if (options.verbose) {
+          console.log(t('info_temp_dir_removed', { path: tempDir }));
+        }
+      } else {
+        cleanSpinner.fail(t('progress_clean_failed'));
+      }
+    }
+
+    process.exit(0);
+  } catch (error) {
+    cloneSpinner.fail(t('progress_clone_failed'));
+    discoverySpinner.fail(t('analysisFailed'));
+    state.progressBar?.fail(t('analysisFailed'));
+    console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+
+    // 发生错误时也要清理临时目录
+    if (shouldCleanup && tempDir) {
+      await removeTempDir(tempDir);
+    }
+
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { createConfigCommand } from './commands/config.js';
 import { createMcpInstallCommand } from './commands/mcp-install.js';
 import { createUninstallCommand } from './commands/uninstall.js';
 import { createUpdateCommand } from './commands/update.js';
+import { createCloneAnalyzeCommand } from './commands/clone-and-analyze.js';
 import { t, setLocale, type Locale } from '../i18n/index.js';
 import { loadLocaleFromConfig } from '../config/index.js';
 import { getSupportedLanguageNames } from '../parser/index.js';
@@ -31,6 +32,7 @@ ${t('cli_examples')}
   $ fuck-u-code analyze ./src --top 10       # ${t('cli_example_analyze_top')}
   $ fuck-u-code analyze . --format markdown  # ${t('cli_example_analyze_markdown')}
   $ fuck-u-code analyze . --locale zh        # ${t('cli_example_analyze_locale')}
+  $ fuck-u-code clone-and-analyze https://github.com/user/repo.git  # ${t('cmd_clone_analyze_example')}
   $ fuck-u-code ai-review . --model gpt-4o   # ${t('cli_example_ai_review')}
   $ fuck-u-code mcp-install claude           # ${t('cli_example_mcp_install')}
   $ fuck-u-code update                       # ${t('cmd_update_example')}
@@ -47,6 +49,7 @@ ${t('cli_supported_languages')}
   program.addCommand(createMcpInstallCommand());
   program.addCommand(createUpdateCommand());
   program.addCommand(createUninstallCommand());
+  program.addCommand(createCloneAnalyzeCommand());
 
   return program;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -426,5 +426,26 @@
   "json_severity_info": "No issues detected, code quality is good",
   "json_severity_warning": "Minor issues that should be addressed",
   "json_severity_error": "Significant issues that need attention",
-  "json_severity_critical": "Critical issues that must be fixed"
+  "json_severity_critical": "Critical issues that must be fixed",
+
+  "cmd_clone_analyze_description": "Clone git repository and analyze code quality",
+  "cmd_clone_analyze_example": "Clone and analyze remote repository",
+  "cmd_clone_analyze_example_url": "Clone and analyze specified git repository",
+  "cmd_clone_analyze_example_output": "Clone and analyze, output Markdown report",
+  "cmd_clone_analyze_example_keep": "Clone and analyze, keep temp directory",
+  "progress_cloning": "Cloning repository...",
+  "progress_clone_success": "Repository cloned successfully",
+  "progress_clone_failed": "Failed to clone repository",
+  "progress_cleaning": "Cleaning up temp directory...",
+  "progress_clean_complete": "Temp directory cleaned",
+  "progress_clean_failed": "Failed to clean temp directory",
+  "error_git_clone_failed": "Failed to clone {url}: {reason}",
+  "error_target_dir_not_created": "Target directory not created",
+  "error_remove_temp_dir_failed": "Failed to remove temp directory {path}: {error}",
+  "error_invalid_git_url": "Invalid git URL: {url}",
+  "error_git_not_installed": "git is not installed or not in PATH",
+  "info_temp_dir_created": "Temp directory created: {path}",
+  "info_temp_dir_kept": "Temp directory kept: {path}",
+  "info_temp_dir_removed": "Temp directory removed: {path}",
+  "warn_git_url_not_valid": "Git URL may be invalid: {url}"
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -426,5 +426,26 @@
   "json_severity_info": "Проблем не обнаружено, качество кода хорошее",
   "json_severity_warning": "Незначительные проблемы, которые следует устранить",
   "json_severity_error": "Значительные проблемы, требующие внимания",
-  "json_severity_critical": "Критические проблемы, которые необходимо исправить"
+  "json_severity_critical": "Критические проблемы, которые необходимо исправить",
+
+  "cmd_clone_analyze_description": "Клонировать git репозиторий и проанализировать качество кода",
+  "cmd_clone_analyze_example": "Клонировать и проанализировать удаленный репозиторий",
+  "cmd_clone_analyze_example_url": "Клонировать и проанализировать указанный git репозиторий",
+  "cmd_clone_analyze_example_output": "Клонировать и проанализировать, вывести отчёт в Markdown",
+  "cmd_clone_analyze_example_keep": "Клонировать и проанализировать, сохранить временную директорию",
+  "progress_cloning": "Клонирование репозитория...",
+  "progress_clone_success": "Репозиторий успешно клонирован",
+  "progress_clone_failed": "Не удалось клонировать репозиторий",
+  "progress_cleaning": "Очистка временной директории...",
+  "progress_clean_complete": "Временная директория очищена",
+  "progress_clean_failed": "Не удалось очистить временную директорию",
+  "error_git_clone_failed": "Не удалось клонировать {url}: {reason}",
+  "error_target_dir_not_created": "Целевая директория не создана",
+  "error_remove_temp_dir_failed": "Не удалось удалить временную директорию {path}: {error}",
+  "error_invalid_git_url": "Неверный git URL: {url}",
+  "error_git_not_installed": "git не установлен или не в PATH",
+  "info_temp_dir_created": "Временная директория создана: {path}",
+  "info_temp_dir_kept": "Временная директория сохранена: {path}",
+  "info_temp_dir_removed": "Временная директория удалена: {path}",
+  "warn_git_url_not_valid": "Git URL может быть недействительным: {url}"
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -427,5 +427,26 @@
   "json_severity_info": "未检测到问题，代码质量良好",
   "json_severity_warning": "应该处理的轻微问题",
   "json_severity_error": "需要关注的重大问题",
-  "json_severity_critical": "必须修复的严重问题"
+  "json_severity_critical": "必须修复的严重问题",
+
+  "cmd_clone_analyze_description": "克隆 git 仓库并分析代码质量",
+  "cmd_clone_analyze_example": "克隆并分析远程仓库",
+  "cmd_clone_analyze_example_url": "克隆并分析指定的 git 仓库",
+  "cmd_clone_analyze_example_output": "克隆并分析，输出 Markdown 报告",
+  "cmd_clone_analyze_example_keep": "克隆并分析，保留临时目录",
+  "progress_cloning": "正在克隆仓库...",
+  "progress_clone_success": "仓库克隆成功",
+  "progress_clone_failed": "仓库克隆失败",
+  "progress_cleaning": "正在清理临时目录...",
+  "progress_clean_complete": "临时目录已清理",
+  "progress_clean_failed": "清理临时目录失败",
+  "error_git_clone_failed": "克隆 {url} 失败：{reason}",
+  "error_target_dir_not_created": "目标目录未创建",
+  "error_remove_temp_dir_failed": "删除临时目录 {path} 失败：{error}",
+  "error_invalid_git_url": "无效的 git URL: {url}",
+  "error_git_not_installed": "git 未安装或不在 PATH 中",
+  "info_temp_dir_created": "临时目录已创建：{path}",
+  "info_temp_dir_kept": "临时目录已保留：{path}",
+  "info_temp_dir_removed": "临时目录已删除：{path}",
+  "warn_git_url_not_valid": "git URL 可能无效：{url}"
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,192 @@
+/**
+ * Git 工具函数
+ * 支持克隆远程仓库到本地临时目录
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { exists } from './fs.js';
+import { t } from '../i18n/index.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Git clone 选项
+ */
+export interface GitCloneOptions {
+  /** 克隆的目标目录路径，如果不指定则创建临时目录 */
+  targetDir?: string;
+  /** git clone 附加参数 */
+  extraArgs?: string[];
+  /** 是否显示详细输出 */
+  verbose?: boolean;
+  /** 超时时间（毫秒） */
+  timeout?: number;
+}
+
+/**
+ * Git clone 结果
+ */
+export interface GitCloneResult {
+  /** 克隆成功或失败 */
+  success: boolean;
+  /** 克隆到的本地目录路径 */
+  targetDir?: string;
+  /** 错误信息（如果失败） */
+  error?: string;
+  /** 是否是临时目录 */
+  isTempDir: boolean;
+}
+
+/**
+ * 从 git URL 克隆仓库
+ * @param gitUrl git 仓库地址（如：https://github.com/user/repo.git）
+ * @param options 克隆选项
+ * @returns GitCloneResult
+ */
+export async function gitClone(
+  gitUrl: string,
+  options: GitCloneOptions = {}
+): Promise<GitCloneResult> {
+  const { targetDir, extraArgs = [], verbose = false, timeout = 120000 } = options;
+
+  // 确定目标目录
+  let cloneTarget: string;
+  let isTempDir: boolean;
+
+  if (targetDir) {
+    cloneTarget = targetDir;
+    isTempDir = false;
+  } else {
+    // 创建临时目录
+    const tempBase = tmpdir();
+    const uniqueId = randomUUID().slice(0, 8);
+    cloneTarget = join(tempBase, `tmp_proj_${uniqueId}`);
+    isTempDir = true;
+  }
+
+  // 构建 git clone 命令
+  const args = ['clone', gitUrl, cloneTarget, ...extraArgs];
+  const command = `git ${args.join(' ')}`;
+
+  try {
+    // 检查 git 是否可用
+    await execAsync('git --version', { timeout: 5000 });
+
+    // 执行 git clone
+    const { stdout, stderr } = await execAsync(command, {
+      timeout,
+      encoding: 'utf-8',
+    });
+
+    if (verbose && stdout) {
+      console.log(stdout);
+    }
+    if (verbose && stderr) {
+      console.error(stderr);
+    }
+
+    // 验证克隆结果
+    const cloned = await exists(cloneTarget);
+    if (!cloned) {
+      return {
+        success: false,
+        error: t('error_git_clone_failed', { url: gitUrl, reason: t('error_target_dir_not_created') }),
+        isTempDir,
+      };
+    }
+
+    return {
+      success: true,
+      targetDir: cloneTarget,
+      isTempDir,
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      targetDir: isTempDir ? cloneTarget : undefined,
+      error: t('error_git_clone_failed', { url: gitUrl, reason: errorMsg }),
+      isTempDir,
+    };
+  }
+}
+
+/**
+ * 删除临时目录
+ * @param dirPath 要删除的目录路径
+ * @param force 是否强制删除（忽略错误）
+ * @returns 删除是否成功
+ */
+export async function removeTempDir(dirPath: string, force = true): Promise<boolean> {
+  try {
+    const dirExists = await exists(dirPath);
+    if (!dirExists) {
+      return true;
+    }
+
+    await rm(dirPath, {
+      recursive: true,
+      force,
+      maxRetries: 3,
+      retryDelay: 200,
+    });
+
+    return true;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(t('error_remove_temp_dir_failed', { path: dirPath, error: errorMsg }));
+    return false;
+  }
+}
+
+/**
+ * 解析 git URL，提取仓库名称
+ * @param gitUrl git 仓库地址
+ * @returns 仓库名称（不含 .git 后缀）
+ */
+export function parseRepoName(gitUrl: string): string {
+  // 移除末尾的 .git
+  let url = gitUrl.replace(/\.git$/, '');
+
+  // 处理 SSH 格式：git@github.com:user/repo
+  if (url.startsWith('git@')) {
+    const match = url.match(/git@[^:]+:(.+)/);
+    if (match && match[1]) {
+      url = match[1];
+    }
+  }
+
+  // 获取最后一段路径
+  const parts = url.split('/');
+  const repoName = parts[parts.length - 1];
+  return repoName || 'unknown-repo';
+}
+
+/**
+ * 验证 git URL 格式
+ * @param gitUrl 待验证的 URL
+ * @returns 是否是有效的 git URL
+ */
+export function isValidGitUrl(gitUrl: string): boolean {
+  // HTTPS 格式
+  if (/^https?:\/\/.+/.test(gitUrl)) {
+    return true;
+  }
+
+  // SSH 格式
+  if (/^git@[^:]+:.+/.test(gitUrl)) {
+    return true;
+  }
+
+  // 本地路径（也允许）
+  if (/^[./~]/.test(gitUrl)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
- 新增 `clone-and-analyze` 命令，支持通过 git URL 克隆远程仓库并分析代码质量
- 添加 git 工具函数，提供仓库克隆、临时目录管理和 URL 验证功能
- 在 CLI 主程序中注册新命令并更新帮助文档
- 为支持多语言，在英文、中文和俄语翻译文件中添加相关文本